### PR TITLE
Improve GUI security by hiding passwords by default.

### DIFF
--- a/futurehome/config.yaml
+++ b/futurehome/config.yaml
@@ -27,9 +27,9 @@ options:
 schema:
   hub_ip: 'str?'
   fh_username: 'str?'
-  fh_password: 'str?'
+  fh_password: 'password?'
   tp_username: 'str?'
-  tp_password: 'str?'
+  tp_password: 'password?'
   demo_mode: 'bool?'
   show_debug_log: 'bool?'
 


### PR DESCRIPTION
These changes hide the passwords for "Local API Password" and "Thingsplex Password Optional" by default. They can be revealed by a button.



Example (not from this addon):
<img width="1244" height="86" alt="image" src="https://github.com/user-attachments/assets/cd9c4bb6-0d71-459e-8ac7-d06d2cd96e92" />
