### PR TITLE
URGENT! Push version 1.2.1!

### DIFF
--- a/futurehome/config.yaml
+++ b/futurehome/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Futurehome
-version: '1.2.0'
+version: '1.2.1'
 slug: futurehome
 description: Local Futurehome Smarthub integration
 url: 'https://github.com/adrianjagielak/home-assistant-futurehome'


### PR DESCRIPTION
We missed updating this when rolling back the changes from our light entity test. As a result, any out_lvl_switch that could function as a light won’t appear in Home Assistant until this version is properly released. At that point, HA will recognize it as an update. Alternatively, a manual reinstall MAY also resolve the issue.