### PR TITLE
Fix invalid device_class + unit_of_measurement combinations for HA 2026.5

### DIFF
--- a/futurehome/src/services/_meter.ts
+++ b/futurehome/src/services/_meter.ts
@@ -370,15 +370,24 @@ export function _meter__components(
           break;
       }
 
+      // Map FIMP unit names to HA-compatible unit_of_measurement values
+      const haUnit =
+        unit === 'power_factor' ? '' :
+        unit === 'VAr' ? 'var' :
+        unit === 'kVArh' ? 'kvarh' : unit;
+
       const component: SensorComponent = {
         unique_id: componentId,
         platform: 'sensor',
         entity_category: 'diagnostic',
         name: friendlyName,
-        unit_of_measurement: unit,
         state_class: stateClass,
         value_template: `{{ value_json['${svc.addr}'].meter.${unit}.val | default(0) }}`,
       };
+
+      if (haUnit) {
+        component.unit_of_measurement = haUnit;
+      }
 
       if (deviceClass) {
         component.device_class = deviceClass;
@@ -460,15 +469,23 @@ export function _meter__components(
           break;
       }
 
+      // Map FIMP unit names to HA-compatible unit_of_measurement values
+      const haUnit =
+        unit === 'VAr' ? 'var' :
+        unit === 'kVArh' ? 'kvarh' : unit;
+
       const component: SensorComponent = {
         unique_id: componentId,
         platform: 'sensor',
         entity_category: 'diagnostic',
         name: friendlyName,
-        unit_of_measurement: unit,
         state_class: stateClass,
         value_template: `{{ value_json['${svc.addr}'].meter_export.${unit}.val | default(0) }}`,
       };
+
+      if (haUnit) {
+        component.unit_of_measurement = haUnit;
+      }
 
       if (deviceClass) {
         component.device_class = deviceClass;
@@ -510,14 +527,25 @@ export function _meter__components(
 
       // Determine unit based on value name
       let unit = '';
-      if (
+      const isPhasePower =
         valueName.startsWith('p_') ||
         valueName.startsWith('p1') ||
         valueName.startsWith('p2') ||
-        valueName.startsWith('p3') ||
-        valueName === 'dc_p'
-      ) {
+        valueName.startsWith('p3');
+      if (isPhasePower && valueName.includes('_react')) {
+        unit = 'var';
+      } else if (isPhasePower && valueName.includes('_apparent')) {
+        unit = 'VA';
+      } else if (isPhasePower || valueName === 'dc_p') {
         unit = 'W';
+      } else if (
+        (valueName.startsWith('e_') ||
+          valueName.startsWith('e1') ||
+          valueName.startsWith('e2') ||
+          valueName.startsWith('e3')) &&
+        valueName.includes('_react')
+      ) {
+        unit = 'kvarh';
       } else if (
         valueName.startsWith('e_') ||
         valueName.startsWith('e1') ||
@@ -565,9 +593,9 @@ export function _meter__components(
       }
 
       // Set suggested display precision
-      if (unit === 'kWh') {
+      if (unit === 'kWh' || unit === 'kvarh') {
         component.suggested_display_precision = 3;
-      } else if (unit === 'W' || unit === 'V' || unit === 'A') {
+      } else if (unit === 'W' || unit === 'V' || unit === 'A' || unit === 'var' || unit === 'VA') {
         component.suggested_display_precision = 1;
       } else if (unit === 'Hz') {
         component.suggested_display_precision = 2;

--- a/futurehome/src/services/_sensor_numeric.ts
+++ b/futurehome/src/services/_sensor_numeric.ts
@@ -72,12 +72,15 @@ export function _sensor_numeric__components(
 
   if (!data) return undefined;
 
-  const device_class = data[0];
+  let device_class = data[0];
   const name = data[1];
   let unit = svc.props?.sup_units?.[0] ?? data[2];
   if (unit === 'C') unit = '°C';
   if (unit === 'F') unit = '°F';
   if (unit === 'kph') unit = 'km/h';
+  if (unit === 'Lux') unit = 'lx';
+  // HA rejects illuminance + %; drop device_class for percentage-reporting sensors
+  if (device_class === 'illuminance' && unit === '%') device_class = undefined;
   const state_class = data[3];
 
   return {


### PR DESCRIPTION
Fixes #31

## Summary

HA 2026.5 enforces strict validation of `device_class` ↔ `unit_of_measurement` pairs in MQTT discovery payloads (previously only warnings). This caused four categories of entities to fail discovery.

### Fixes

| `device_class` | Was sending | Now sends |
|---|---|---|
| `power_factor` | `"power_factor"` (the FIMP field name) | field omitted |
| `illuminance` | `"Lux"` | `"lx"` |
| `illuminance` | `"%"` (Z-Wave %-luminance sensors) | device_class dropped (generic sensor) |
| `reactive_power` — regular/export meter | `"VAr"` | `"var"` |
| `reactive_power` — extended values (`p_import_react`, per-phase, etc.) | `"W"` (fell through to generic power branch) | `"var"` |
| `apparent_power` — extended values | `"W"` | `"VA"` |
| `reactive_energy` — extended values | `"kWh"` | `"kvarh"` |

### Changes

**`src/services/_meter.ts`**
- Regular and export meter sections: compute a `haUnit` from the raw FIMP unit string before building the sensor component, so the data-path template (`meter.VAr.val`) stays correct while the MQTT-advertised unit matches HA's expectations.
- Extended values section: restructure the unit-determination block to check for `_react` / `_apparent` suffixes before falling through to the generic `p_*` → `"W"` branch.
- Update `suggested_display_precision` to cover `var`, `VA`, and `kvarh`.

**`src/services/_sensor_numeric.ts`**
- Normalise `"Lux"` → `"lx"` alongside the existing `"C"` / `"F"` / `"kph"` normalisations.
- Drop `device_class: illuminance` when the reported unit is `"%"`, so the entity registers as a generic sensor rather than producing a validation error.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHz3BWbSNigtEiqKJRcwYr)_